### PR TITLE
Add Apache 2.0 license headers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -79,7 +96,6 @@
                 </configuration>
             </plugin>
           <!-- Licence Maven Plugin (add license info to source files) -->
-<!--
           <plugin>
             <groupId>com.mycila</groupId>
             <artifactId>license-maven-plugin</artifactId>
@@ -88,6 +104,7 @@
               <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
               <properties>
                 <owner>Peter Murray-Rust</owner>
+                <email>pm286@cam.ac.uk</email>
               </properties>
               <excludes>
                 <exclude>**/README.md</exclude>
@@ -106,7 +123,6 @@
               </execution>
             </executions>
           </plugin>
--->
         </plugins>
     </build>
 

--- a/src/main/java/org/xmlcml/www/CMLRuleValidator.java
+++ b/src/main/java/org/xmlcml/www/CMLRuleValidator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www;
 
 import nu.xom.Attribute;

--- a/src/main/java/org/xmlcml/www/CmlLiteValidator.java
+++ b/src/main/java/org/xmlcml/www/CmlLiteValidator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www;
 
 import nu.xom.Builder;

--- a/src/main/java/org/xmlcml/www/ConventionValidator.java
+++ b/src/main/java/org/xmlcml/www/ConventionValidator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www;
 
 import nu.xom.*;

--- a/src/main/java/org/xmlcml/www/SchemaValidator.java
+++ b/src/main/java/org/xmlcml/www/SchemaValidator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www;
 
 import nu.xom.Element;

--- a/src/main/java/org/xmlcml/www/URIValidator.java
+++ b/src/main/java/org/xmlcml/www/URIValidator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www;
 
 import nu.xom.*;

--- a/src/main/java/org/xmlcml/www/ValidationReport.java
+++ b/src/main/java/org/xmlcml/www/ValidationReport.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www;
 
 import nu.xom.Document;

--- a/src/main/java/org/xmlcml/www/ValidationResult.java
+++ b/src/main/java/org/xmlcml/www/ValidationResult.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www;
 
 /**

--- a/src/main/java/org/xmlcml/www/XmlWellFormednessValidator.java
+++ b/src/main/java/org/xmlcml/www/XmlWellFormednessValidator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www;
 
 import nu.xom.Builder;

--- a/src/test/java/org/xmlcml/www/TestUtils.java
+++ b/src/test/java/org/xmlcml/www/TestUtils.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www;
 
 import nu.xom.Builder;

--- a/src/test/java/org/xmlcml/www/convention/dictionary/invalid/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/dictionary/invalid/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.dictionary.invalid;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/dictionary/invalid/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/dictionary/invalid/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.dictionary.invalid;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/convention/dictionary/valid/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/dictionary/valid/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.dictionary.valid;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/dictionary/valid/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/dictionary/valid/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.dictionary.valid;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/convention/dictionary/warning/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/dictionary/warning/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.dictionary.warning;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/dictionary/warning/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/dictionary/warning/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.dictionary.warning;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/convention/molecular/invalid/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/molecular/invalid/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.molecular.invalid;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/molecular/invalid/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/molecular/invalid/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.molecular.invalid;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/convention/molecular/valid/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/molecular/valid/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.molecular.valid;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/molecular/valid/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/molecular/valid/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.molecular.valid;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/convention/molecular/warning/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/molecular/warning/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.molecular.warning;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/molecular/warning/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/molecular/warning/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.molecular.warning;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/convention/simpleUnit/info/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/simpleUnit/info/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.simpleUnit.info;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/simpleUnit/info/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/simpleUnit/info/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.simpleUnit.info;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/convention/simpleUnit/invalid/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/simpleUnit/invalid/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.simpleUnit.invalid;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/simpleUnit/invalid/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/simpleUnit/invalid/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.simpleUnit.invalid;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/convention/simpleUnit/valid/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/simpleUnit/valid/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.simpleUnit.valid;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/simpleUnit/valid/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/simpleUnit/valid/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.simpleUnit.valid;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/convention/unit/invalid/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/unit/invalid/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.unit.invalid;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/unit/invalid/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/unit/invalid/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.unit.invalid;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/convention/unit/valid/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/unit/valid/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.unit.valid;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/unit/valid/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/unit/valid/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.unit.valid;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/convention/unit/warning/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/unit/warning/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.unit.warning;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/unit/warning/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/unit/warning/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.unit.warning;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/convention/unitType/invalid/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/unitType/invalid/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.unitType.invalid;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/unitType/invalid/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/unitType/invalid/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.unitType.invalid;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/convention/unitType/valid/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/unitType/valid/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.unitType.valid;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/unitType/valid/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/unitType/valid/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.unitType.valid;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/convention/unitType/warning/ConventionTest.java
+++ b/src/test/java/org/xmlcml/www/convention/unitType/warning/ConventionTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.unitType.warning;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/convention/unitType/warning/SchemaTest.java
+++ b/src/test/java/org/xmlcml/www/convention/unitType/warning/SchemaTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.convention.unitType.warning;
 
 import org.apache.commons.io.FileUtils;

--- a/src/test/java/org/xmlcml/www/schema/invalid/SchemaValidatorTest.java
+++ b/src/test/java/org/xmlcml/www/schema/invalid/SchemaValidatorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.schema.invalid;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/schema/valid/SchemaValidatorTest.java
+++ b/src/test/java/org/xmlcml/www/schema/valid/SchemaValidatorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.schema.valid;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/schema/warning/SchemaValidatorTest.java
+++ b/src/test/java/org/xmlcml/www/schema/warning/SchemaValidatorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.schema.warning;
 
 import nu.xom.Document;

--- a/src/test/java/org/xmlcml/www/xml/invalid/XmlWellFormednessTest.java
+++ b/src/test/java/org/xmlcml/www/xml/invalid/XmlWellFormednessTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.xml.invalid;
 
 import org.junit.After;

--- a/src/test/java/org/xmlcml/www/xml/valid/XmlWellFormednessTest.java
+++ b/src/test/java/org/xmlcml/www/xml/valid/XmlWellFormednessTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2010 Peter Murray-Rust (pm286@cam.ac.uk)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.xmlcml.www.xml.valid;
 
 import org.junit.After;


### PR DESCRIPTION
Added with the help of the maven-license-plugin:

```xml
<!-- Licence Maven Plugin (add license info to source files) -->
<plugin>
  <groupId>com.mycila</groupId>
  <artifactId>license-maven-plugin</artifactId>
  <version>2.11</version>
  <configuration>
    <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
    <properties>
      <owner>Peter Murray-Rust</owner>
      <email></email>
    </properties>
    <excludes>
      <exclude>**/README.md</exclude>
      <exclude>LICENSE.txt</exclude>
      <exclude>.gitignore</exclude>
      <exclude>src/test/resources/**</exclude>
      <exclude>src/main/resources/**</exclude>
      <exclude>junk/**</exclude>
    </excludes>
  </configuration>
  <executions>
    <execution>
      <goals>
        <goal>check</goal>
      </goals>
    </execution>
  </executions>
</plugin>
```

Contributors have been identified via `git shortlog --summary --email --numbered` and added as developers in `pom.xml`.
